### PR TITLE
Fix line spacing and add session persistence

### DIFF
--- a/App/settings/settingsmanager.cpp
+++ b/App/settings/settingsmanager.cpp
@@ -4,6 +4,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonValue>
 #include <QStandardPaths>
@@ -50,6 +51,10 @@ void SettingsManager::initializeDefaults()
 
     // Settings version for migration
     m_defaults["settingsVersion"] = SETTINGS_VERSION;
+    
+    // Session state defaults
+    m_defaults["lastProjectPath"] = "";
+    m_defaults["openTabs"] = QJsonArray();
 
     // Initialize settings with defaults
     m_settings = m_defaults;


### PR DESCRIPTION
- Fix line spacing using custom QPlainTextDocumentLayout (CSS line-height doesn't work with QPlainTextEdit)
- Reduce default line spacing from 160% to 130%
- Remove unused ExtraLineSpacingDocumentLayout class
- Persist last project path between sessions
- Persist open tabs between sessions
- Restore project and tabs on app startup