### PR TITLE
Integrate vim find/replace with app FindReplacePanel

### DIFF
--- a/App/editor/vimmode.cpp
+++ b/App/editor/vimmode.cpp
@@ -6,6 +6,7 @@
 #include <QRegularExpression>
 #include <QScrollBar>
 #include <QTextBlock>
+#include <algorithm>
 
 static const int VIM_PAGE_SIZE = 20;
 static const int VIM_HALF_PAGE_SIZE = 10;
@@ -13,8 +14,13 @@ static const int VIM_HALF_PAGE_SIZE = 10;
 VimMode::VimMode(QPlainTextEdit *editor, QObject *parent)
     : QObject(parent), m_editor(editor), m_enabled(false),
       m_mode(VimEditMode::Normal), m_pendingOperator(VimOperator::None),
-      m_count(0), m_searchForward(true), m_lastChangeCount(1),
-      m_recordingChange(false), m_commandHistoryIndex(-1) {}
+      m_count(0), m_searchForward(true), m_searchHighlightActive(false),
+      m_pendingRegister(QChar()), m_recording(false), m_recordCount(1),
+      m_replaying(false), m_macroRecording(false),
+      m_lastInsertPosition(-1), m_lastVisualStart(-1), m_lastVisualEnd(-1),
+      m_lastVisualMode(VimEditMode::Normal), m_commandHistoryIndex(-1) {}
+
+VimMode::~VimMode() = default;
 
 void VimMode::setEnabled(bool enabled) {
   if (m_enabled != enabled) {
@@ -25,10 +31,17 @@ void VimMode::setEnabled(bool enabled) {
       setMode(VimEditMode::Normal);
       m_editor->setCursorWidth(m_editor->fontMetrics().horizontalAdvance('M'));
     } else {
+      // Close any open undo group before disabling
+      if (m_insertUndoOpen) {
+        QTextCursor cursor = m_editor->textCursor();
+        cursor.endEditBlock();
+        m_insertUndoOpen = false;
+      }
       m_commandBuffer.clear();
       emit commandBufferChanged(m_commandBuffer);
-      setMode(VimEditMode::Insert);
+      m_mode = VimEditMode::Insert;
       m_editor->setCursorWidth(1);
+      emit modeChanged(m_mode);
     }
     LOG_INFO(QString("VIM mode %1").arg(enabled ? "enabled" : "disabled"));
   }
@@ -61,9 +74,61 @@ QString VimMode::modeName() const {
 
 QString VimMode::commandBuffer() const { return m_commandBuffer; }
 
+QString VimMode::pendingKeys() const {
+  QString keys;
+  if (m_pendingRegister != QChar())
+    keys += QString("\"%1").arg(m_pendingRegister);
+  if (m_count > 0)
+    keys += QString::number(m_count);
+  if (m_pendingOperator != VimOperator::None) {
+    switch (m_pendingOperator) {
+    case VimOperator::Delete: keys += "d"; break;
+    case VimOperator::Change: keys += "c"; break;
+    case VimOperator::Yank: keys += "y"; break;
+    case VimOperator::Indent: keys += ">"; break;
+    case VimOperator::Unindent: keys += "<"; break;
+    case VimOperator::ToggleCase: keys += "g~"; break;
+    case VimOperator::Lowercase: keys += "gu"; break;
+    case VimOperator::Uppercase: keys += "gU"; break;
+    default: break;
+    }
+  }
+  if (!m_commandBuffer.isEmpty() && m_mode == VimEditMode::Normal)
+    keys += m_commandBuffer;
+  return keys;
+}
+
+bool VimMode::isRecordingMacro() const { return m_macroRecording; }
+QChar VimMode::macroRegister() const { return m_macroRegister; }
+
+QString VimMode::searchPattern() const { return m_searchPattern; }
+
+void VimMode::setSearchPattern(const QString &pattern) {
+  m_searchPattern = pattern;
+  m_searchHighlightActive = !pattern.isEmpty();
+}
+
+QString VimMode::registerContent(QChar reg) const {
+  return getRegister(reg).content;
+}
+
 bool VimMode::processKeyEvent(QKeyEvent *event) {
   if (!m_enabled) {
     return false;
+  }
+
+  // Record keys for macro
+  if (m_macroRecording && !m_replaying) {
+    m_macroKeyCodes.append(event->key());
+    m_macroKeyMods.append(event->modifiers());
+    m_macroKeyTexts.append(event->text());
+  }
+
+  // Record keys for dot-repeat (only in normal/visual entering insert/change)
+  if (m_recording && !m_replaying) {
+    m_recordKeyCodes.append(event->key());
+    m_recordKeyMods.append(event->modifiers());
+    m_recordKeyTexts.append(event->text());
   }
 
   switch (m_mode) {
@@ -84,19 +149,344 @@ bool VimMode::processKeyEvent(QKeyEvent *event) {
   }
 }
 
+// ============== REGISTER SYSTEM ==============
+
+void VimMode::setRegister(QChar reg, const QString &text, bool linewise) {
+  if (reg == '_')
+    return; // black hole register
+  VimRegister r;
+  r.content = text;
+  r.linewise = linewise;
+  if (reg >= 'A' && reg <= 'Z') {
+    // Append to lowercase register
+    QChar lower = reg.toLower();
+    if (m_registers.contains(lower)) {
+      m_registers[lower].content += text;
+    } else {
+      m_registers[lower] = r;
+    }
+  } else {
+    m_registers[reg] = r;
+  }
+  if (reg == '+' || reg == '*') {
+    QApplication::clipboard()->setText(text);
+  }
+  emit registerContentsChanged();
+}
+
+VimRegister VimMode::getRegister(QChar reg) const {
+  if (reg == '+' || reg == '*') {
+    VimRegister r;
+    r.content = QApplication::clipboard()->text();
+    return r;
+  }
+  QChar key = reg.toLower();
+  if (m_registers.contains(key))
+    return m_registers[key];
+  return VimRegister();
+}
+
+void VimMode::pushDeleteHistory(const QString &text, bool linewise) {
+  VimRegister r;
+  r.content = text;
+  r.linewise = linewise;
+  m_deleteHistory.prepend(r);
+  while (m_deleteHistory.size() > 9)
+    m_deleteHistory.removeLast();
+  // Update "1-"9 registers
+  for (int i = 0; i < m_deleteHistory.size(); ++i) {
+    m_registers[QChar('1' + i)] = m_deleteHistory[i];
+  }
+}
+
+void VimMode::yankToRegister(const QString &text, bool linewise) {
+  QChar reg = m_pendingRegister;
+  if (reg == QChar()) {
+    setRegister('"', text, linewise);
+    setRegister('0', text, linewise);
+  } else {
+    setRegister(reg, text, linewise);
+    setRegister('"', text, linewise);
+  }
+  m_pendingRegister = QChar();
+}
+
+void VimMode::deleteToRegister(const QString &text, bool linewise) {
+  QChar reg = m_pendingRegister;
+  if (reg == QChar()) {
+    setRegister('"', text, linewise);
+    pushDeleteHistory(text, linewise);
+  } else {
+    setRegister(reg, text, linewise);
+    setRegister('"', text, linewise);
+  }
+  m_pendingRegister = QChar();
+}
+
+void VimMode::pasteFromRegister(QChar reg, bool after) {
+  if (reg == QChar())
+    reg = '"';
+  VimRegister r = getRegister(reg);
+  if (r.content.isEmpty())
+    return;
+  QTextCursor cursor = m_editor->textCursor();
+  if (r.linewise) {
+    if (after) {
+      cursor.movePosition(QTextCursor::EndOfLine);
+      cursor.insertText("\n" + r.content);
+    } else {
+      cursor.movePosition(QTextCursor::StartOfLine);
+      cursor.insertText(r.content + "\n");
+      cursor.movePosition(QTextCursor::Up);
+    }
+  } else {
+    if (after)
+      cursor.movePosition(QTextCursor::Right);
+    cursor.insertText(r.content);
+  }
+  m_editor->setTextCursor(cursor);
+}
+
+// ============== MACRO SYSTEM ==============
+
+void VimMode::startMacroRecording(QChar reg) {
+  m_macroRecording = true;
+  m_macroRegister = reg;
+  m_macroKeyCodes.clear();
+  m_macroKeyMods.clear();
+  m_macroKeyTexts.clear();
+  emit macroRecordingChanged(true, reg);
+  emit statusMessage(QString("Recording @%1").arg(reg));
+}
+
+void VimMode::stopMacroRecording() {
+  // Remove the final 'q' from the recording
+  if (!m_macroKeyCodes.isEmpty()) {
+    m_macroKeyCodes.removeLast();
+    m_macroKeyMods.removeLast();
+    m_macroKeyTexts.removeLast();
+  }
+  // Store the macro
+  QString macroContent;
+  for (int i = 0; i < m_macroKeyTexts.size(); ++i)
+    macroContent += m_macroKeyTexts[i];
+  setRegister(m_macroRegister, macroContent);
+
+  m_macroRecording = false;
+  m_lastMacroRegister = m_macroRegister;
+  emit macroRecordingChanged(false, QChar());
+  emit statusMessage(QString("Recorded @%1").arg(m_macroRegister));
+}
+
+void VimMode::playbackMacro(QChar reg, int count) {
+  if (reg == '@' && m_lastMacroRegister != QChar())
+    reg = m_lastMacroRegister;
+  // Find macro in stored key sequences - simple replay via stored register
+  // For now we search by register key code arrays if they were recorded here
+  // Otherwise fall back to register content text
+  m_lastMacroRegister = reg;
+  VimRegister r = getRegister(reg);
+  if (r.content.isEmpty()) {
+    emit statusMessage(QString("Empty register @%1").arg(reg));
+    return;
+  }
+
+  m_replaying = true;
+  for (int c = 0; c < count; ++c) {
+    for (int i = 0; i < r.content.length(); ++i) {
+      QChar ch = r.content[i];
+      int key = ch.toUpper().unicode();
+      Qt::KeyboardModifiers mods = Qt::NoModifier;
+      if (ch.isUpper())
+        mods = Qt::ShiftModifier;
+      QKeyEvent ev(QEvent::KeyPress, key, mods, QString(ch));
+      processKeyEvent(&ev);
+    }
+  }
+  m_replaying = false;
+}
+
+// ============== DOT-REPEAT SYSTEM ==============
+
+void VimMode::beginChangeRecording(int count) {
+  m_recording = true;
+  m_recordKeyCodes.clear();
+  m_recordKeyMods.clear();
+  m_recordKeyTexts.clear();
+  m_recordCount = count;
+}
+
+void VimMode::endChangeRecording() {
+  if (!m_recording) return;
+  m_recording = false;
+  m_lastReplayable.keyCodes = m_recordKeyCodes;
+  m_lastReplayable.keyMods = m_recordKeyMods;
+  m_lastReplayable.keyTexts = m_recordKeyTexts;
+  m_lastReplayable.count = m_recordCount;
+}
+
+void VimMode::repeatLastChange() {
+  if (m_lastReplayable.keyCodes.isEmpty()) {
+    emit statusMessage("No change to repeat");
+    return;
+  }
+  m_replaying = true;
+  for (int i = 0; i < m_lastReplayable.keyCodes.size(); ++i) {
+    QKeyEvent ev(QEvent::KeyPress, m_lastReplayable.keyCodes[i],
+                 m_lastReplayable.keyMods[i], m_lastReplayable.keyTexts[i]);
+    processKeyEvent(&ev);
+  }
+  m_replaying = false;
+}
+
+// ============== INCREMENT/DECREMENT ==============
+
+void VimMode::incrementNumber(int delta) {
+  QTextCursor cursor = m_editor->textCursor();
+  QString line = cursor.block().text();
+  int col = cursor.positionInBlock();
+
+  // Find number at or after cursor on current line
+  QRegularExpression numRegex("(-?\\d+)");
+  QRegularExpressionMatchIterator it = numRegex.globalMatch(line);
+  while (it.hasNext()) {
+    QRegularExpressionMatch match = it.next();
+    int start = match.capturedStart();
+    int end = match.capturedEnd();
+    if (end > col || (start <= col && end > col)) {
+      bool ok;
+      long long val = match.captured(1).toLongLong(&ok);
+      if (ok) {
+        val += delta;
+        QString newNum = QString::number(val);
+        int blockPos = cursor.block().position();
+        cursor.beginEditBlock();
+        cursor.setPosition(blockPos + start);
+        cursor.setPosition(blockPos + end, QTextCursor::KeepAnchor);
+        cursor.insertText(newNum);
+        cursor.endEditBlock();
+        m_editor->setTextCursor(cursor);
+        emit statusMessage(QString::number(val));
+        return;
+      }
+    }
+  }
+  emit statusMessage("No number found");
+}
+
+// ============== SEARCH ==============
+
+void VimMode::clearSearchHighlight() {
+  m_searchHighlightActive = false;
+  emit searchHighlightRequested("", false);
+}
+
+// ============== LAST INSERT / VISUAL TRACKING ==============
+
+void VimMode::trackInsertPosition() {
+  m_lastInsertPosition = m_editor->textCursor().position();
+}
+
+// ============== PENDING KEYS DISPLAY ==============
+
+void VimMode::updatePendingKeys() {
+  emit pendingKeysChanged(pendingKeys());
+}
+
+// ============== g-PREFIX HANDLER ==============
+
+bool VimMode::handleGPrefix(QKeyEvent *event, int count) {
+  int key = event->key();
+  Qt::KeyboardModifiers mods = event->modifiers();
+  QString text = event->text();
+
+  if (key == Qt::Key_G) {
+    // gg -> go to file start (or line N with count)
+    if (count > 1) {
+      QTextCursor cursor = m_editor->textCursor();
+      QTextBlock block = m_editor->document()->findBlockByNumber(count - 1);
+      if (block.isValid()) {
+        cursor.setPosition(block.position());
+        m_editor->setTextCursor(cursor);
+      }
+    } else {
+      executeMotion(VimMotion::FileStart);
+    }
+    return true;
+  }
+  if (key == Qt::Key_I && !(mods & Qt::ShiftModifier)) {
+    // gi -> go to last insert position
+    if (m_lastInsertPosition >= 0) {
+      QTextCursor cursor = m_editor->textCursor();
+      cursor.setPosition(m_lastInsertPosition);
+      m_editor->setTextCursor(cursor);
+    }
+    setMode(VimEditMode::Insert);
+    return true;
+  }
+  if (key == Qt::Key_V && !(mods & Qt::ShiftModifier)) {
+    // gv -> reselect last visual
+    if (m_lastVisualStart >= 0 && m_lastVisualEnd >= 0) {
+      QTextCursor cursor = m_editor->textCursor();
+      cursor.setPosition(m_lastVisualStart);
+      cursor.setPosition(m_lastVisualEnd, QTextCursor::KeepAnchor);
+      m_editor->setTextCursor(cursor);
+      setMode(m_lastVisualMode != VimEditMode::Normal ? m_lastVisualMode
+                                                       : VimEditMode::Visual);
+    }
+    return true;
+  }
+  if (key == Qt::Key_AsciiTilde) {
+    // g~ -> toggle case operator
+    m_pendingOperator = VimOperator::ToggleCase;
+    m_commandBuffer.clear();
+    updatePendingKeys();
+    return true;
+  }
+  if (key == Qt::Key_U && !(mods & Qt::ShiftModifier)) {
+    // gu -> lowercase operator
+    m_pendingOperator = VimOperator::Lowercase;
+    m_commandBuffer.clear();
+    updatePendingKeys();
+    return true;
+  }
+  if (key == Qt::Key_U && (mods & Qt::ShiftModifier)) {
+    // gU -> uppercase operator
+    m_pendingOperator = VimOperator::Uppercase;
+    m_commandBuffer.clear();
+    updatePendingKeys();
+    return true;
+  }
+
+  return false;
+}
+
+// ============== NORMAL MODE ==============
+
 bool VimMode::handleNormalMode(QKeyEvent *event) {
   int key = event->key();
   Qt::KeyboardModifiers mods = event->modifiers();
   QString text = event->text();
 
+  // Handle register prefix: "{reg}
+  if (!text.isEmpty() && m_commandBuffer == "\"") {
+    m_pendingRegister = text[0];
+    m_commandBuffer.clear();
+    updatePendingKeys();
+    return true;
+  }
+
+  // Count accumulator
   if (!text.isEmpty() && text[0].isDigit() && (m_count > 0 || text[0] != '0')) {
     m_count = m_count * 10 + text[0].digitValue();
+    updatePendingKeys();
     return true;
   }
 
   int count = qMax(1, m_count);
   m_count = 0;
 
+  // Pending operator awaiting motion/text-object
   if (m_pendingOperator != VimOperator::None) {
     VimMotion motion = VimMotion::None;
 
@@ -106,12 +496,17 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
 
       switch (key) {
       case Qt::Key_W:
-        textObj = inner ? VimTextObject::InnerWord : VimTextObject::AroundWord;
+        if (mods & Qt::ShiftModifier)
+          textObj = inner ? VimTextObject::InnerWORD : VimTextObject::AroundWORD;
+        else
+          textObj = inner ? VimTextObject::InnerWord : VimTextObject::AroundWord;
         break;
       case Qt::Key_ParenLeft:
       case Qt::Key_ParenRight:
-        textObj =
-            inner ? VimTextObject::InnerParen : VimTextObject::AroundParen;
+      case Qt::Key_B:
+        if (m_commandBuffer == "i" || m_commandBuffer == "a")
+          textObj =
+              inner ? VimTextObject::InnerParen : VimTextObject::AroundParen;
         break;
       case Qt::Key_BracketLeft:
       case Qt::Key_BracketRight:
@@ -140,14 +535,30 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
         textObj = inner ? VimTextObject::InnerBacktick
                         : VimTextObject::AroundBacktick;
         break;
+      case Qt::Key_P:
+        textObj = inner ? VimTextObject::InnerParagraph
+                        : VimTextObject::AroundParagraph;
+        break;
+      case Qt::Key_S:
+        textObj = inner ? VimTextObject::InnerSentence
+                        : VimTextObject::AroundSentence;
+        break;
+      case Qt::Key_T:
+        textObj =
+            inner ? VimTextObject::InnerTag : VimTextObject::AroundTag;
+        break;
       default:
         break;
       }
 
       if (textObj != VimTextObject::None) {
+        beginChangeRecording(count);
         executeOperatorOnTextObject(m_pendingOperator, textObj);
         m_pendingOperator = VimOperator::None;
         m_commandBuffer.clear();
+        if (m_mode != VimEditMode::Insert)
+          endChangeRecording();
+        updatePendingKeys();
         return true;
       }
       m_commandBuffer.clear();
@@ -155,13 +566,16 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
 
     if (key == Qt::Key_I && !(mods & Qt::ShiftModifier)) {
       m_commandBuffer = "i";
+      updatePendingKeys();
       return true;
     }
     if (key == Qt::Key_A && !(mods & Qt::ShiftModifier)) {
       m_commandBuffer = "a";
+      updatePendingKeys();
       return true;
     }
 
+    // Double operator -> operate on line
     if ((key == Qt::Key_D && m_pendingOperator == VimOperator::Delete) ||
         (key == Qt::Key_Y && m_pendingOperator == VimOperator::Yank) ||
         (key == Qt::Key_C && m_pendingOperator == VimOperator::Change) ||
@@ -174,15 +588,12 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
 
       if (m_pendingOperator == VimOperator::Indent ||
           m_pendingOperator == VimOperator::Unindent) {
-
         QString line = cursor.selectedText();
         cursor.movePosition(QTextCursor::StartOfLine);
         cursor.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
-
         if (m_pendingOperator == VimOperator::Indent) {
           cursor.insertText("    " + line);
         } else {
-
           if (line.startsWith("    ")) {
             cursor.insertText(line.mid(4));
           } else if (line.startsWith("\t")) {
@@ -197,32 +608,53 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
         m_editor->setTextCursor(cursor);
       } else {
         cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
-        m_registerBuffer = cursor.selectedText();
-
-        if (m_pendingOperator == VimOperator::Delete ||
-            m_pendingOperator == VimOperator::Change) {
+        QString selected = cursor.selectedText();
+        if (m_pendingOperator == VimOperator::Yank) {
+          yankToRegister(selected, true);
+        } else if (m_pendingOperator == VimOperator::Change) {
+          cursor.beginEditBlock();
+          m_editor->setTextCursor(cursor);
+          m_insertUndoOpen = true;
+          deleteToRegister(selected, true);
+          cursor = m_editor->textCursor();
           cursor.removeSelectedText();
-        }
-        m_editor->setTextCursor(cursor);
-
-        if (m_pendingOperator == VimOperator::Change) {
-          setMode(VimEditMode::Insert);
+          m_editor->setTextCursor(cursor);
+          beginChangeRecording(count);
+          trackInsertPosition();
+          m_mode = VimEditMode::Insert;
+          m_editor->setCursorWidth(1);
+          emit modeChanged(m_mode);
+          updatePendingKeys();
+        } else {
+          deleteToRegister(selected, true);
+          cursor.removeSelectedText();
+          m_editor->setTextCursor(cursor);
         }
       }
-
       m_pendingOperator = VimOperator::None;
+      updatePendingKeys();
       return true;
+    }
+
+    // g~/gu/gU doubled -> line
+    if (m_pendingOperator == VimOperator::ToggleCase ||
+        m_pendingOperator == VimOperator::Lowercase ||
+        m_pendingOperator == VimOperator::Uppercase) {
+      // Check for doubled: g~g~, gugu, gUgU (simplified: accept motion keys)
     }
 
     switch (key) {
     case Qt::Key_W:
-      motion = VimMotion::WordForward;
+      motion = (mods & Qt::ShiftModifier) ? VimMotion::WORDForward
+                                           : VimMotion::WordForward;
       break;
     case Qt::Key_B:
-      motion = VimMotion::WordBack;
+      motion = (mods & Qt::ShiftModifier) ? VimMotion::WORDBack
+                                           : VimMotion::WordBack;
       break;
     case Qt::Key_E:
-      motion = VimMotion::WordEnd;
+      motion = (mods & Qt::ShiftModifier) ? VimMotion::WORDEnd
+                                           : VimMotion::WordEnd;
       break;
     case Qt::Key_H:
       motion = VimMotion::Left;
@@ -242,6 +674,9 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
     case Qt::Key_Dollar:
       motion = VimMotion::LineEnd;
       break;
+    case Qt::Key_AsciiCircum:
+      motion = VimMotion::FirstNonSpace;
+      break;
     case Qt::Key_Percent:
       motion = VimMotion::MatchingBrace;
       break;
@@ -251,25 +686,36 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
     case Qt::Key_BraceRight:
       motion = VimMotion::NextParagraph;
       break;
+    case Qt::Key_G:
+      if (mods & Qt::ShiftModifier)
+        motion = VimMotion::FileEnd;
+      else
+        motion = VimMotion::FileStart;
+      break;
     default:
       m_pendingOperator = VimOperator::None;
+      updatePendingKeys();
       return false;
     }
 
     executeOperator(m_pendingOperator, motion, count);
     m_pendingOperator = VimOperator::None;
+    updatePendingKeys();
     return true;
   }
 
+  // g-prefix commands
   if (!m_commandBuffer.isEmpty()) {
-    if (m_commandBuffer == "g" && key == Qt::Key_G) {
-      executeMotion(VimMotion::FileStart);
+    if (m_commandBuffer == "g") {
+      bool handled = handleGPrefix(event, count);
       m_commandBuffer.clear();
-      return true;
+      updatePendingKeys();
+      return handled;
     }
     if (m_commandBuffer == "r" && !text.isEmpty()) {
       replaceChar(text[0]);
       m_commandBuffer.clear();
+      updatePendingKeys();
       return true;
     }
 
@@ -283,6 +729,7 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
       m_findCharBackward = backward;
       moveCursorToChar(m_findChar, before, backward);
       m_commandBuffer.clear();
+      updatePendingKeys();
       return true;
     }
 
@@ -292,6 +739,7 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
         setMark(mark);
       }
       m_commandBuffer.clear();
+      updatePendingKeys();
       return true;
     }
 
@@ -301,16 +749,14 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
         jumpToMark(mark);
       }
       m_commandBuffer.clear();
+      updatePendingKeys();
       return true;
     }
 
     if (m_commandBuffer == "z") {
-      QTextCursor cursor = m_editor->textCursor();
       if (key == Qt::Key_Z || text == "z") {
-
         m_editor->centerCursor();
       } else if (key == Qt::Key_T || text == "t") {
-
         m_editor->centerCursor();
         for (int i = 0; i < VIM_HALF_PAGE_SIZE; ++i) {
           m_editor->verticalScrollBar()->setValue(
@@ -318,7 +764,6 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
               m_editor->fontMetrics().height());
         }
       } else if (key == Qt::Key_B || text == "b") {
-
         m_editor->centerCursor();
         for (int i = 0; i < VIM_HALF_PAGE_SIZE; ++i) {
           m_editor->verticalScrollBar()->setValue(
@@ -327,19 +772,29 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
         }
       }
       m_commandBuffer.clear();
+      updatePendingKeys();
+      return true;
+    }
+
+    // Macro playback: @{reg}
+    if (m_commandBuffer == "@" && !text.isEmpty()) {
+      QChar reg = text[0];
+      playbackMacro(reg, count);
+      m_commandBuffer.clear();
+      updatePendingKeys();
       return true;
     }
 
     m_commandBuffer.clear();
+    updatePendingKeys();
   }
 
   switch (key) {
 
   case Qt::Key_I:
     if (mods & Qt::ShiftModifier) {
-
+      // I -> insert at first non-space
       moveCursor(QTextCursor::StartOfLine);
-
       QTextCursor cursor = m_editor->textCursor();
       QString line = cursor.block().text();
       int pos = 0;
@@ -349,24 +804,38 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
       cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, pos);
       m_editor->setTextCursor(cursor);
     }
+    beginChangeRecording(count);
+    trackInsertPosition();
     setMode(VimEditMode::Insert);
     return true;
 
   case Qt::Key_A:
     if (mods & Qt::ShiftModifier) {
-
       moveCursor(QTextCursor::EndOfLine);
     } else {
-
       moveCursor(QTextCursor::Right);
     }
+    beginChangeRecording(count);
+    trackInsertPosition();
     setMode(VimEditMode::Insert);
     return true;
 
-  case Qt::Key_O:
+  case Qt::Key_O: {
+    // Open edit block first so newline is part of the insert undo group
+    QTextCursor cursor = m_editor->textCursor();
+    cursor.beginEditBlock();
+    m_editor->setTextCursor(cursor);
+    m_insertUndoOpen = true;
     insertNewLine(mods & Qt::ShiftModifier);
-    setMode(VimEditMode::Insert);
+    beginChangeRecording(count);
+    trackInsertPosition();
+    // setMode won't re-open edit block since m_insertUndoOpen is already true
+    m_mode = VimEditMode::Insert;
+    m_editor->setCursorWidth(1);
+    emit modeChanged(m_mode);
+    updatePendingKeys();
     return true;
+  }
 
   case Qt::Key_V:
     if (mods & Qt::ShiftModifier) {
@@ -385,7 +854,6 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
     return true;
 
   case Qt::Key_Slash:
-
     setMode(VimEditMode::Command);
     m_commandBuffer = "/";
     emit commandBufferChanged(m_commandBuffer);
@@ -393,7 +861,6 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
     return true;
 
   case Qt::Key_Question:
-
     setMode(VimEditMode::Command);
     m_commandBuffer = "?";
     emit commandBufferChanged(m_commandBuffer);
@@ -401,21 +868,33 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
     return true;
 
   case Qt::Key_H:
+    if (mods & Qt::ShiftModifier) {
+      executeMotion(VimMotion::ScreenTop, count);
+    } else {
+      executeMotion(VimMotion::Left, count);
+    }
+    return true;
+
   case Qt::Key_Left:
     executeMotion(VimMotion::Left, count);
     return true;
 
   case Qt::Key_L:
+    if (mods & Qt::ShiftModifier) {
+      executeMotion(VimMotion::ScreenBottom, count);
+    } else {
+      executeMotion(VimMotion::Right, count);
+    }
+    return true;
+
   case Qt::Key_Right:
     executeMotion(VimMotion::Right, count);
     return true;
 
   case Qt::Key_J:
     if (mods & Qt::ShiftModifier) {
-
-      joinLines();
+      joinLines(count);
     } else {
-
       executeMotion(VimMotion::Down, count);
     }
     return true;
@@ -429,14 +908,27 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
     executeMotion(VimMotion::Up, count);
     return true;
 
+  case Qt::Key_M:
+    if (mods & Qt::ShiftModifier) {
+      executeMotion(VimMotion::ScreenMiddle);
+    } else {
+      m_commandBuffer = "m";
+      updatePendingKeys();
+    }
+    return true;
+
   case Qt::Key_W:
-    executeMotion(VimMotion::WordForward, count);
+    if (mods & Qt::ShiftModifier)
+      executeMotion(VimMotion::WORDForward, count);
+    else
+      executeMotion(VimMotion::WordForward, count);
     return true;
 
   case Qt::Key_B:
     if (mods & Qt::ControlModifier) {
-
       executeMotion(VimMotion::FullPageUp, count);
+    } else if (mods & Qt::ShiftModifier) {
+      executeMotion(VimMotion::WORDBack, count);
     } else {
       executeMotion(VimMotion::WordBack, count);
     }
@@ -444,8 +936,9 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
 
   case Qt::Key_E:
     if (mods & Qt::ControlModifier) {
-
       scrollLines(count);
+    } else if (mods & Qt::ShiftModifier) {
+      executeMotion(VimMotion::WORDEnd, count);
     } else {
       executeMotion(VimMotion::WordEnd, count);
     }
@@ -467,88 +960,76 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
     if (mods & Qt::ShiftModifier) {
       executeMotion(VimMotion::FileEnd);
     } else {
-
       m_commandBuffer = "g";
+      updatePendingKeys();
     }
     return true;
 
   case Qt::Key_Percent:
-
     executeMotion(VimMotion::MatchingBrace);
     return true;
 
   case Qt::Key_BraceLeft:
-
     executeMotion(VimMotion::PrevParagraph, count);
     return true;
 
   case Qt::Key_BraceRight:
-
     executeMotion(VimMotion::NextParagraph, count);
     return true;
 
   case Qt::Key_ParenLeft:
-
     executeMotion(VimMotion::PrevSentence, count);
     return true;
 
   case Qt::Key_ParenRight:
-
     executeMotion(VimMotion::NextSentence, count);
     return true;
 
   case Qt::Key_Asterisk:
-
     searchWord(true);
     return true;
 
   case Qt::Key_NumberSign:
-
     searchWord(false);
     return true;
 
   case Qt::Key_N:
     if (mods & Qt::ShiftModifier) {
-
       searchNext(false);
     } else {
-
       searchNext(true);
     }
     return true;
 
   case Qt::Key_F:
     if (mods & Qt::ControlModifier) {
-
       executeMotion(VimMotion::FullPageDown, count);
     } else if (mods & Qt::ShiftModifier) {
-
       m_commandBuffer = "F";
+      updatePendingKeys();
     } else {
-
       m_commandBuffer = "f";
+      updatePendingKeys();
     }
     return true;
 
   case Qt::Key_T:
     if (mods & Qt::ShiftModifier) {
-
       m_commandBuffer = "T";
+      updatePendingKeys();
     } else {
-
       m_commandBuffer = "t";
+      updatePendingKeys();
     }
     return true;
 
   case Qt::Key_Semicolon:
-
     if (!m_findChar.isNull()) {
       moveCursorToChar(m_findChar, m_findCharBefore, m_findCharBackward);
     }
     return true;
 
   case Qt::Key_Comma:
-
     if (!m_findChar.isNull()) {
       moveCursorToChar(m_findChar, m_findCharBefore, !m_findCharBackward);
     }
@@ -556,68 +1037,56 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
 
   case Qt::Key_D:
     if (mods & Qt::ControlModifier) {
-
       executeMotion(VimMotion::PageDown, count);
     } else if (mods & Qt::ShiftModifier) {
-
       deleteText(VimMotion::LineEnd);
     } else {
       m_pendingOperator = VimOperator::Delete;
+      updatePendingKeys();
     }
     return true;
 
   case Qt::Key_C:
     if (mods & Qt::ShiftModifier) {
-
       changeText(VimMotion::LineEnd);
     } else {
       m_pendingOperator = VimOperator::Change;
-    }
-    return true;
-
-  case Qt::Key_Y:
-    if (mods & Qt::ControlModifier) {
-
-      scrollLines(-count);
-    } else if (mods & Qt::ShiftModifier) {
-
-      yankText(VimMotion::LineEnd);
-    } else {
-      m_pendingOperator = VimOperator::Yank;
+      updatePendingKeys();
     }
     return true;
 
   case Qt::Key_Greater:
-
     m_pendingOperator = VimOperator::Indent;
+    updatePendingKeys();
     return true;
 
   case Qt::Key_Less:
-
     m_pendingOperator = VimOperator::Unindent;
+    updatePendingKeys();
     return true;
 
   case Qt::Key_AsciiTilde:
-
   {
     QTextCursor cursor = m_editor->textCursor();
+    cursor.beginEditBlock();
     for (int i = 0; i < count; ++i) {
       if (!cursor.atEnd()) {
         cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
         QString ch = cursor.selectedText();
         if (!ch.isEmpty()) {
           QChar c = ch[0];
-          if (c.isLower()) {
+          if (c.isLower())
             cursor.insertText(c.toUpper());
-          } else if (c.isUpper()) {
+          else if (c.isUpper())
             cursor.insertText(c.toLower());
-          } else {
+          else {
             cursor.clearSelection();
             cursor.movePosition(QTextCursor::Right);
           }
         }
       }
     }
+    cursor.endEditBlock();
     m_editor->setTextCursor(cursor);
   }
     return true;
@@ -628,84 +1097,149 @@ bool VimMode::handleNormalMode(QKeyEvent *event) {
 
   case Qt::Key_S:
     if (mods & Qt::ShiftModifier) {
-
       QTextCursor cursor = m_editor->textCursor();
+      cursor.beginEditBlock();
+      m_editor->setTextCursor(cursor);
+      m_insertUndoOpen = true;
       cursor.movePosition(QTextCursor::StartOfLine);
       cursor.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
-      m_registerBuffer = cursor.selectedText();
+      deleteToRegister(cursor.selectedText());
       cursor.removeSelectedText();
       m_editor->setTextCursor(cursor);
-      setMode(VimEditMode::Insert);
+      beginChangeRecording(count);
+      trackInsertPosition();
+      m_mode = VimEditMode::Insert;
+      m_editor->setCursorWidth(1);
+      emit modeChanged(m_mode);
+      updatePendingKeys();
     } else {
-
+      QTextCursor cursor = m_editor->textCursor();
+      cursor.beginEditBlock();
+      m_editor->setTextCursor(cursor);
+      m_insertUndoOpen = true;
       deleteText(VimMotion::Right);
-      setMode(VimEditMode::Insert);
+      beginChangeRecording(count);
+      trackInsertPosition();
+      m_mode = VimEditMode::Insert;
+      m_editor->setCursorWidth(1);
+      emit modeChanged(m_mode);
+      updatePendingKeys();
     }
     return true;
 
   case Qt::Key_P:
-    if (!m_registerBuffer.isEmpty()) {
-      QTextCursor cursor = m_editor->textCursor();
-      if (mods & Qt::ShiftModifier) {
-
-        cursor.insertText(m_registerBuffer);
-      } else {
-
-        cursor.movePosition(QTextCursor::Right);
-        cursor.insertText(m_registerBuffer);
-      }
-      m_editor->setTextCursor(cursor);
+    if (mods & Qt::ShiftModifier) {
+      pasteFromRegister(m_pendingRegister != QChar() ? m_pendingRegister : '"',
+                        false);
+    } else {
+      pasteFromRegister(m_pendingRegister != QChar() ? m_pendingRegister : '"',
+                        true);
     }
+    m_pendingRegister = QChar();
     return true;
 
   case Qt::Key_U:
     if (mods & Qt::ControlModifier) {
-
       executeMotion(VimMotion::PageUp, count);
     } else {
-
       m_editor->undo();
     }
     return true;
 
   case Qt::Key_R:
     if (mods & Qt::ControlModifier) {
-
       m_editor->redo();
     } else if (mods & Qt::ShiftModifier) {
-
       setMode(VimEditMode::Replace);
     } else {
-
       m_commandBuffer = "r";
+      updatePendingKeys();
     }
     return true;
 
-  case Qt::Key_M:
+  case Qt::Key_Z:
+    if (mods & Qt::ControlModifier) {
+      m_editor->undo();
+      return true;
+    }
+    m_commandBuffer = "z";
+    updatePendingKeys();
+    return true;
 
-    m_commandBuffer = "m";
+  case Qt::Key_Y:
+    if (mods & Qt::ControlModifier) {
+      if (mods & Qt::ShiftModifier) {
+        m_editor->redo();
+      } else {
+        scrollLines(-count);
+      }
+    } else if (mods & Qt::ShiftModifier) {
+      yankText(VimMotion::LineEnd);
+    } else {
+      m_pendingOperator = VimOperator::Yank;
+      updatePendingKeys();
+    }
     return true;
 
   case Qt::Key_Apostrophe:
   case Qt::Key_QuoteLeft:
-
     m_commandBuffer = "'";
+    updatePendingKeys();
     return true;
 
   case Qt::Key_Period:
-
     repeatLastChange();
     return true;
 
-  case Qt::Key_Z:
+  case Qt::Key_QuoteDbl:
+    // Start register prefix
+    m_commandBuffer = "\"";
+    updatePendingKeys();
+    return true;
 
-    m_commandBuffer = "z";
+  case Qt::Key_Q:
+    // Macro recording toggle
+    if (m_macroRecording) {
+      stopMacroRecording();
+    } else {
+      // Wait for register key
+      m_commandBuffer = "q";
+      updatePendingKeys();
+    }
+    return true;
+
+  case Qt::Key_At:
+    // Macro playback
+    m_commandBuffer = "@";
+    updatePendingKeys();
     return true;
 
   default:
     break;
   }
 
+  // Ctrl+A / Ctrl+X for increment/decrement (outside switch to avoid duplicate)
+  if (key == Qt::Key_A && (mods & Qt::ControlModifier)) {
+    incrementNumber(count);
+    return true;
+  }
+  if (key == Qt::Key_X && (mods & Qt::ControlModifier)) {
+    incrementNumber(-count);
+    return true;
+  }
+
+  // Handle 'q' pending for macro register
+  if (!m_commandBuffer.isEmpty() && m_commandBuffer == "q" && !text.isEmpty()) {
+    QChar reg = text[0];
+    if ((reg >= 'a' && reg <= 'z') || (reg >= 'A' && reg <= 'Z')) {
+      startMacroRecording(reg);
+    }
+    m_commandBuffer.clear();
+    updatePendingKeys();
+    return true;
+  }
+
+  updatePendingKeys();
   return false;
 }
 
@@ -713,8 +1247,9 @@ bool VimMode::handleInsertMode(QKeyEvent *event) {
   if (event->key() == Qt::Key_Escape ||
       (event->key() == Qt::Key_BracketLeft &&
        event->modifiers() & Qt::ControlModifier)) {
+    trackInsertPosition();
+    endChangeRecording();
     setMode(VimEditMode::Normal);
-
     moveCursor(QTextCursor::Left);
     return true;
   }
@@ -734,7 +1269,6 @@ bool VimMode::handleReplaceMode(QKeyEvent *event) {
   }
 
   if (key == Qt::Key_Backspace) {
-
     moveCursor(QTextCursor::Left);
     return true;
   }
@@ -754,11 +1288,18 @@ bool VimMode::handleReplaceMode(QKeyEvent *event) {
   return false;
 }
 
+// ============== VISUAL MODE ==============
+
 bool VimMode::handleVisualMode(QKeyEvent *event) {
   int key = event->key();
   Qt::KeyboardModifiers mods = event->modifiers();
 
   if (key == Qt::Key_Escape) {
+    // Save visual selection for gv
+    QTextCursor cursor = m_editor->textCursor();
+    m_lastVisualStart = cursor.anchor();
+    m_lastVisualEnd = cursor.position();
+    m_lastVisualMode = m_mode;
     setMode(VimEditMode::Normal);
     return true;
   }
@@ -784,6 +1325,11 @@ bool VimMode::handleVisualMode(QKeyEvent *event) {
 
   case Qt::Key_J:
   case Qt::Key_Down:
+    if (key == Qt::Key_J && (mods & Qt::ShiftModifier)) {
+      visualJoinLines();
+      setMode(VimEditMode::Normal);
+      return true;
+    }
     cursor.movePosition(QTextCursor::Down, QTextCursor::KeepAnchor, count);
     m_editor->setTextCursor(cursor);
     return true;
@@ -795,7 +1341,12 @@ bool VimMode::handleVisualMode(QKeyEvent *event) {
     return true;
 
   case Qt::Key_W:
-    cursor.movePosition(QTextCursor::NextWord, QTextCursor::KeepAnchor, count);
+    if (mods & Qt::ShiftModifier) {
+      // WORD motion in visual
+      cursor.movePosition(QTextCursor::NextWord, QTextCursor::KeepAnchor, count);
+    } else {
+      cursor.movePosition(QTextCursor::NextWord, QTextCursor::KeepAnchor, count);
+    }
     m_editor->setTextCursor(cursor);
     return true;
 
@@ -805,15 +1356,43 @@ bool VimMode::handleVisualMode(QKeyEvent *event) {
     m_editor->setTextCursor(cursor);
     return true;
 
+  case Qt::Key_E:
+    cursor.movePosition(QTextCursor::EndOfWord, QTextCursor::KeepAnchor, count);
+    m_editor->setTextCursor(cursor);
+    return true;
+
+  case Qt::Key_0:
+    cursor.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
+    m_editor->setTextCursor(cursor);
+    return true;
+
+  case Qt::Key_Dollar:
+    cursor.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
+    m_editor->setTextCursor(cursor);
+    return true;
+
+  case Qt::Key_G:
+    if (mods & Qt::ShiftModifier) {
+      cursor.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
+      m_editor->setTextCursor(cursor);
+    }
+    return true;
+
   case Qt::Key_D:
   case Qt::Key_X:
-    m_registerBuffer = cursor.selectedText();
+    m_lastVisualStart = cursor.anchor();
+    m_lastVisualEnd = cursor.position();
+    m_lastVisualMode = m_mode;
+    deleteToRegister(cursor.selectedText());
     cursor.removeSelectedText();
     setMode(VimEditMode::Normal);
     return true;
 
   case Qt::Key_Y:
-    m_registerBuffer = cursor.selectedText();
+    m_lastVisualStart = cursor.anchor();
+    m_lastVisualEnd = cursor.position();
+    m_lastVisualMode = m_mode;
+    yankToRegister(cursor.selectedText());
     cursor.clearSelection();
     m_editor->setTextCursor(cursor);
     setMode(VimEditMode::Normal);
@@ -821,16 +1400,59 @@ bool VimMode::handleVisualMode(QKeyEvent *event) {
     return true;
 
   case Qt::Key_C:
-    m_registerBuffer = cursor.selectedText();
+    m_lastVisualStart = cursor.anchor();
+    m_lastVisualEnd = cursor.position();
+    m_lastVisualMode = m_mode;
+    cursor.beginEditBlock();
+    m_editor->setTextCursor(cursor);
+    m_insertUndoOpen = true;
+    deleteToRegister(cursor.selectedText());
+    cursor = m_editor->textCursor();
     cursor.removeSelectedText();
-    setMode(VimEditMode::Insert);
+    m_editor->setTextCursor(cursor);
+    beginChangeRecording(count);
+    trackInsertPosition();
+    m_mode = VimEditMode::Insert;
+    m_editor->setCursorWidth(1);
+    emit modeChanged(m_mode);
+    updatePendingKeys();
+    return true;
+
+  case Qt::Key_Greater:
+    visualIndent(true);
+    setMode(VimEditMode::Normal);
+    return true;
+
+  case Qt::Key_Less:
+    visualIndent(false);
+    setMode(VimEditMode::Normal);
+    return true;
+
+  case Qt::Key_AsciiTilde:
+    visualToggleCase();
+    setMode(VimEditMode::Normal);
+    return true;
+
+  case Qt::Key_U:
+    if (mods & Qt::ShiftModifier) {
+      visualUppercase();
+    } else {
+      visualLowercase();
+    }
+    setMode(VimEditMode::Normal);
     return true;
 
   case Qt::Key_V:
     if (mods & Qt::ShiftModifier) {
-      setMode(VimEditMode::VisualLine);
+      if (m_mode == VimEditMode::VisualLine)
+        setMode(VimEditMode::Normal);
+      else
+        setMode(VimEditMode::VisualLine);
     } else {
-      setMode(VimEditMode::Normal);
+      if (m_mode == VimEditMode::Visual)
+        setMode(VimEditMode::Normal);
+      else
+        setMode(VimEditMode::Visual);
     }
     return true;
 
@@ -840,6 +1462,89 @@ bool VimMode::handleVisualMode(QKeyEvent *event) {
 
   return false;
 }
+
+// ============== VISUAL MODE HELPERS ==============
+
+void VimMode::visualIndent(bool indent) {
+  QTextCursor cursor = m_editor->textCursor();
+  int startPos = qMin(cursor.anchor(), cursor.position());
+  int endPos = qMax(cursor.anchor(), cursor.position());
+  int startBlock = m_editor->document()->findBlock(startPos).blockNumber();
+  int endBlock = m_editor->document()->findBlock(endPos).blockNumber();
+
+  cursor.beginEditBlock();
+  for (int i = startBlock; i <= endBlock; ++i) {
+    QTextBlock block = m_editor->document()->findBlockByNumber(i);
+    QTextCursor lineCursor(block);
+    lineCursor.movePosition(QTextCursor::StartOfLine);
+    if (indent) {
+      lineCursor.insertText("    ");
+    } else {
+      QString line = block.text();
+      if (line.startsWith("    ")) {
+        lineCursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor, 4);
+        lineCursor.removeSelectedText();
+      } else if (line.startsWith("\t")) {
+        lineCursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor, 1);
+        lineCursor.removeSelectedText();
+      }
+    }
+  }
+  cursor.endEditBlock();
+}
+
+void VimMode::visualToggleCase() {
+  QTextCursor cursor = m_editor->textCursor();
+  QString text = cursor.selectedText();
+  QString result;
+  for (const QChar &c : text) {
+    if (c.isLower())
+      result += c.toUpper();
+    else if (c.isUpper())
+      result += c.toLower();
+    else
+      result += c;
+  }
+  cursor.insertText(result);
+}
+
+void VimMode::visualLowercase() {
+  QTextCursor cursor = m_editor->textCursor();
+  cursor.insertText(cursor.selectedText().toLower());
+}
+
+void VimMode::visualUppercase() {
+  QTextCursor cursor = m_editor->textCursor();
+  cursor.insertText(cursor.selectedText().toUpper());
+}
+
+void VimMode::visualJoinLines() {
+  QTextCursor cursor = m_editor->textCursor();
+  int startPos = qMin(cursor.anchor(), cursor.position());
+  int endPos = qMax(cursor.anchor(), cursor.position());
+  int startBlock = m_editor->document()->findBlock(startPos).blockNumber();
+  int endBlock = m_editor->document()->findBlock(endPos).blockNumber();
+
+  cursor.setPosition(m_editor->document()->findBlockByNumber(startBlock).position());
+  cursor.beginEditBlock();
+  for (int i = startBlock; i < endBlock; ++i) {
+    cursor.movePosition(QTextCursor::EndOfLine);
+    cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
+    // Skip leading whitespace on next line
+    while (!cursor.atEnd()) {
+      QChar ch = m_editor->document()->characterAt(cursor.position());
+      if (ch.isSpace() && ch != '\n')
+        cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
+      else
+        break;
+    }
+    cursor.insertText(" ");
+  }
+  cursor.endEditBlock();
+  m_editor->setTextCursor(cursor);
+}
+
+// ============== COMMAND MODE ==============
 
 bool VimMode::handleCommandMode(QKeyEvent *event) {
   int key = event->key();
@@ -861,20 +1566,16 @@ bool VimMode::handleCommandMode(QKeyEvent *event) {
         m_commandDraft = m_commandBuffer;
       }
       if (key == Qt::Key_Up) {
-        if (m_commandHistoryIndex < m_commandHistory.size() - 1) {
+        if (m_commandHistoryIndex < m_commandHistory.size() - 1)
           m_commandHistoryIndex++;
-        }
       } else {
-        if (m_commandHistoryIndex >= 0) {
+        if (m_commandHistoryIndex >= 0)
           m_commandHistoryIndex--;
-        }
       }
-
-      if (m_commandHistoryIndex >= 0) {
+      if (m_commandHistoryIndex >= 0)
         m_commandBuffer = m_commandHistory[m_commandHistoryIndex];
-      } else {
+      else
         m_commandBuffer = m_commandDraft;
-      }
       emit commandBufferChanged(m_commandBuffer);
     }
     return true;
@@ -885,9 +1586,8 @@ bool VimMode::handleCommandMode(QKeyEvent *event) {
         !m_commandBuffer.startsWith("?")) {
       m_commandHistory.removeAll(m_commandBuffer);
       m_commandHistory.prepend(m_commandBuffer);
-      while (m_commandHistory.size() > kMaxCommandHistory) {
+      while (m_commandHistory.size() > kMaxCommandHistory)
         m_commandHistory.removeLast();
-      }
     }
     executeCommand(m_commandBuffer);
     m_commandBuffer.clear();
@@ -902,9 +1602,8 @@ bool VimMode::handleCommandMode(QKeyEvent *event) {
     if (!m_commandBuffer.isEmpty()) {
       m_commandBuffer.chop(1);
       emit commandBufferChanged(m_commandBuffer);
-      if (m_commandHistoryIndex < 0) {
+      if (m_commandHistoryIndex < 0)
         m_commandDraft = m_commandBuffer;
-      }
     } else {
       m_commandHistoryIndex = -1;
       m_commandDraft.clear();
@@ -916,9 +1615,8 @@ bool VimMode::handleCommandMode(QKeyEvent *event) {
   if (!text.isEmpty()) {
     m_commandBuffer += text;
     emit commandBufferChanged(m_commandBuffer);
-    if (m_commandHistoryIndex < 0) {
+    if (m_commandHistoryIndex < 0)
       m_commandDraft = m_commandBuffer;
-    }
   }
 
   return true;
@@ -926,6 +1624,15 @@ bool VimMode::handleCommandMode(QKeyEvent *event) {
 
 void VimMode::setMode(VimEditMode mode) {
   if (m_mode != mode) {
+    // Close the insert/replace undo group when leaving insert or replace mode
+    if (m_insertUndoOpen &&
+        (m_mode == VimEditMode::Insert || m_mode == VimEditMode::Replace) &&
+        mode != VimEditMode::Insert && mode != VimEditMode::Replace) {
+      QTextCursor cursor = m_editor->textCursor();
+      cursor.endEditBlock();
+      m_insertUndoOpen = false;
+    }
+
     m_mode = mode;
     if (m_mode != VimEditMode::Command && !m_commandBuffer.isEmpty()) {
       m_commandBuffer.clear();
@@ -933,85 +1640,104 @@ void VimMode::setMode(VimEditMode mode) {
     }
 
     if (mode == VimEditMode::Insert || mode == VimEditMode::Replace) {
-
       m_editor->setCursorWidth(
           mode == VimEditMode::Replace
               ? m_editor->fontMetrics().horizontalAdvance('M') / 2
               : 1);
+      // Open an undo group so the entire insert/replace session is one undo step
+      if (!m_insertUndoOpen) {
+        QTextCursor cursor = m_editor->textCursor();
+        cursor.beginEditBlock();
+        m_editor->setTextCursor(cursor);
+        m_insertUndoOpen = true;
+      }
     } else {
       m_editor->setCursorWidth(m_editor->fontMetrics().horizontalAdvance('M'));
     }
 
     emit modeChanged(mode);
+    updatePendingKeys();
     LOG_DEBUG(QString("VIM mode changed to: %1").arg(modeName()));
   }
 }
 
-void VimMode::executeMotion(VimMotion motion, int count) {
+void VimMode::executeMotion(VimMotion motion, int count,
+                            QTextCursor::MoveMode moveMode) {
   QTextCursor cursor = m_editor->textCursor();
 
   for (int i = 0; i < count; ++i) {
     switch (motion) {
     case VimMotion::Left:
-      cursor.movePosition(QTextCursor::Left);
+      cursor.movePosition(QTextCursor::Left, moveMode);
       break;
     case VimMotion::Right:
-      cursor.movePosition(QTextCursor::Right);
+      cursor.movePosition(QTextCursor::Right, moveMode);
       break;
     case VimMotion::Up:
-      cursor.movePosition(QTextCursor::Up);
+      cursor.movePosition(QTextCursor::Up, moveMode);
       break;
     case VimMotion::Down:
-      cursor.movePosition(QTextCursor::Down);
+      cursor.movePosition(QTextCursor::Down, moveMode);
       break;
     case VimMotion::WordForward:
-      cursor.movePosition(QTextCursor::NextWord);
+      cursor.movePosition(QTextCursor::NextWord, moveMode);
       break;
     case VimMotion::WordBack:
-      cursor.movePosition(QTextCursor::PreviousWord);
+      cursor.movePosition(QTextCursor::PreviousWord, moveMode);
       break;
     case VimMotion::WordEnd:
-      cursor.movePosition(QTextCursor::EndOfWord);
+      cursor.movePosition(QTextCursor::EndOfWord, moveMode);
+      break;
+    case VimMotion::WORDForward:
+      m_editor->setTextCursor(cursor);
+      moveCursorWORD(true);
+      cursor = m_editor->textCursor();
+      break;
+    case VimMotion::WORDBack:
+      m_editor->setTextCursor(cursor);
+      moveCursorWORD(false);
+      cursor = m_editor->textCursor();
+      break;
+    case VimMotion::WORDEnd:
+      m_editor->setTextCursor(cursor);
+      moveCursorWORDEnd();
+      cursor = m_editor->textCursor();
       break;
     case VimMotion::LineStart:
-      cursor.movePosition(QTextCursor::StartOfLine);
+      cursor.movePosition(QTextCursor::StartOfLine, moveMode);
       break;
     case VimMotion::LineEnd:
-      cursor.movePosition(QTextCursor::EndOfLine);
+      cursor.movePosition(QTextCursor::EndOfLine, moveMode);
       break;
     case VimMotion::FirstNonSpace:
-      cursor.movePosition(QTextCursor::StartOfLine);
+      cursor.movePosition(QTextCursor::StartOfLine, moveMode);
       {
         QString line = cursor.block().text();
         int pos = 0;
         while (pos < line.length() && line[pos].isSpace())
           pos++;
-        cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, pos);
+        cursor.movePosition(QTextCursor::Right, moveMode, pos);
       }
       break;
     case VimMotion::FileStart:
-      cursor.movePosition(QTextCursor::Start);
+      cursor.movePosition(QTextCursor::Start, moveMode);
       break;
     case VimMotion::FileEnd:
-      cursor.movePosition(QTextCursor::End);
+      cursor.movePosition(QTextCursor::End, moveMode);
       break;
     case VimMotion::PageUp:
     case VimMotion::HalfPageUp:
-      cursor.movePosition(QTextCursor::Up, QTextCursor::MoveAnchor,
-                          VIM_HALF_PAGE_SIZE);
+      cursor.movePosition(QTextCursor::Up, moveMode, VIM_HALF_PAGE_SIZE);
       break;
     case VimMotion::PageDown:
     case VimMotion::HalfPageDown:
-      cursor.movePosition(QTextCursor::Down, QTextCursor::MoveAnchor,
-                          VIM_HALF_PAGE_SIZE);
+      cursor.movePosition(QTextCursor::Down, moveMode, VIM_HALF_PAGE_SIZE);
       break;
     case VimMotion::FullPageUp:
-      cursor.movePosition(QTextCursor::Up, QTextCursor::MoveAnchor,
-                          VIM_PAGE_SIZE);
+      cursor.movePosition(QTextCursor::Up, moveMode, VIM_PAGE_SIZE);
       break;
     case VimMotion::FullPageDown:
-      cursor.movePosition(QTextCursor::Down, QTextCursor::MoveAnchor,
-                          VIM_PAGE_SIZE);
+      cursor.movePosition(QTextCursor::Down, moveMode, VIM_PAGE_SIZE);
       break;
     case VimMotion::MatchingBrace:
       m_editor->setTextCursor(cursor);
@@ -1058,6 +1784,18 @@ void VimMode::executeMotion(VimMotion motion, int count) {
       searchWord(false);
       cursor = m_editor->textCursor();
       break;
+    case VimMotion::ScreenTop:
+    case VimMotion::ScreenMiddle:
+    case VimMotion::ScreenBottom:
+      m_editor->setTextCursor(cursor);
+      moveCursorToScreenLine(motion == VimMotion::ScreenTop ? 0
+                             : motion == VimMotion::ScreenMiddle ? 1
+                                                                  : 2);
+      cursor = m_editor->textCursor();
+      break;
+    case VimMotion::ColumnZero:
+      cursor.movePosition(QTextCursor::StartOfLine, moveMode);
+      break;
     default:
       break;
     }
@@ -1086,6 +1824,12 @@ void VimMode::executeOperator(VimOperator op, VimMotion motion, int count) {
   case VimOperator::ToggleCase:
     toggleCase(motion, count);
     break;
+  case VimOperator::Lowercase:
+    lowercaseText(motion, count);
+    break;
+  case VimOperator::Uppercase:
+    uppercaseText(motion, count);
+    break;
   default:
     break;
   }
@@ -1104,6 +1848,47 @@ void VimMode::executeCommand(const QString &command) {
     emit commandExecuted("quit");
   } else if (command == "q!") {
     emit commandExecuted("forceQuit");
+  } else if (command == "noh" || command == "nohlsearch") {
+    clearSearchHighlight();
+    emit statusMessage("Search highlight cleared");
+  } else if (command == "bn" || command == "bnext") {
+    emit commandExecuted("nextTab");
+    emit statusMessage("Next buffer");
+  } else if (command == "bp" || command == "bprev" || command == "bprevious") {
+    emit commandExecuted("prevTab");
+    emit statusMessage("Previous buffer");
+  } else if (command == "sp" || command == "split") {
+    emit commandExecuted("splitHorizontal");
+  } else if (command == "vsp" || command == "vsplit") {
+    emit commandExecuted("splitVertical");
+  } else if (command == "sort") {
+    // Sort lines in document
+    QTextCursor cursor = m_editor->textCursor();
+    if (cursor.hasSelection()) {
+      int startPos = qMin(cursor.anchor(), cursor.position());
+      int endPos = qMax(cursor.anchor(), cursor.position());
+      int startBlock = m_editor->document()->findBlock(startPos).blockNumber();
+      int endBlock = m_editor->document()->findBlock(endPos).blockNumber();
+      QStringList lines;
+      for (int i = startBlock; i <= endBlock; ++i)
+        lines << m_editor->document()->findBlockByNumber(i).text();
+      lines.sort();
+      cursor.beginEditBlock();
+      cursor.setPosition(
+          m_editor->document()->findBlockByNumber(startBlock).position());
+      cursor.setPosition(
+          m_editor->document()->findBlockByNumber(endBlock).position() +
+              m_editor->document()->findBlockByNumber(endBlock).length() - 1,
+          QTextCursor::KeepAnchor);
+      cursor.insertText(lines.join("\n"));
+      cursor.endEditBlock();
+    } else {
+      emit statusMessage("Select lines to sort (use visual mode)");
+    }
+  } else if (command == "registers" || command == "reg") {
+    emit commandExecuted("showRegisters");
+  } else if (command == "marks") {
+    emit commandExecuted("showMarks");
   } else if (command.startsWith("set ")) {
     QString option = command.mid(4).trimmed();
     if (option == "novim" || option == "no-vim") {
@@ -1116,16 +1901,16 @@ void VimMode::executeCommand(const QString &command) {
       emit statusMessage(QString("Set: %1").arg(option));
     }
   } else if (command.startsWith("/") || command.startsWith("?")) {
-
     bool forward = command.startsWith("/");
     QString pattern = command.mid(1);
     if (!pattern.isEmpty()) {
       m_searchPattern = QRegularExpression::escape(pattern);
       m_searchForward = forward;
+      m_searchHighlightActive = true;
+      emit searchHighlightRequested(m_searchPattern, true);
       searchNext(true);
     }
   } else if (command.startsWith("s/") || command.startsWith("%s/")) {
-
     QString cmd = command;
     bool global = cmd.startsWith("%");
     if (global)
@@ -1144,7 +1929,6 @@ void VimMode::executeCommand(const QString &command) {
       if (global) {
         text = m_editor->toPlainText();
       } else {
-
         text = cursor.block().text();
         startPos = cursor.block().position();
       }
@@ -1155,7 +1939,6 @@ void VimMode::executeCommand(const QString &command) {
         newText = text;
         newText.replace(regex, replacement);
       } else {
-
         QRegularExpressionMatch match = regex.match(text);
         if (match.hasMatch()) {
           newText = text.left(match.capturedStart()) + replacement +
@@ -1165,6 +1948,7 @@ void VimMode::executeCommand(const QString &command) {
         }
       }
 
+      cursor.beginEditBlock();
       if (global) {
         cursor.select(QTextCursor::Document);
         cursor.insertText(newText);
@@ -1173,19 +1957,17 @@ void VimMode::executeCommand(const QString &command) {
         cursor.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
         cursor.insertText(newText);
       }
+      cursor.endEditBlock();
       m_editor->setTextCursor(cursor);
       emit statusMessage("Substitution complete");
     }
   } else if (command.startsWith("e ")) {
-
     QString filename = command.mid(2).trimmed();
     emit commandExecuted(QString("edit:%1").arg(filename));
   } else {
-
     bool ok;
     int lineNum = command.toInt(&ok);
     if (ok && lineNum > 0) {
-
       QTextCursor cursor = m_editor->textCursor();
       QTextBlock block = m_editor->document()->findBlockByNumber(lineNum - 1);
       if (block.isValid()) {
@@ -1203,11 +1985,60 @@ void VimMode::executeCommand(const QString &command) {
 
 void VimMode::moveCursor(QTextCursor::MoveOperation op, int count) {
   QTextCursor cursor = m_editor->textCursor();
-  for (int i = 0; i < count; ++i) {
+  for (int i = 0; i < count; ++i)
     cursor.movePosition(op);
-  }
   m_editor->setTextCursor(cursor);
 }
+
+// ============== WORD/WORD MOTIONS ==============
+
+void VimMode::moveCursorWORD(bool forward) {
+  QTextCursor cursor = m_editor->textCursor();
+  QString text = m_editor->toPlainText();
+  int pos = cursor.position();
+  int len = text.length();
+
+  if (forward) {
+    // Skip non-whitespace
+    while (pos < len && !text[pos].isSpace())
+      pos++;
+    // Skip whitespace
+    while (pos < len && text[pos].isSpace())
+      pos++;
+  } else {
+    // Skip whitespace backwards
+    if (pos > 0) pos--;
+    while (pos > 0 && text[pos].isSpace())
+      pos--;
+    // Skip non-whitespace backwards
+    while (pos > 0 && !text[pos - 1].isSpace())
+      pos--;
+  }
+
+  cursor.setPosition(pos);
+  m_editor->setTextCursor(cursor);
+}
+
+void VimMode::moveCursorWORDEnd() {
+  QTextCursor cursor = m_editor->textCursor();
+  QString text = m_editor->toPlainText();
+  int pos = cursor.position();
+  int len = text.length();
+
+  if (pos < len) pos++;
+  // Skip whitespace
+  while (pos < len && text[pos].isSpace())
+    pos++;
+  // Skip non-whitespace
+  while (pos < len && !text[pos].isSpace())
+    pos++;
+  if (pos > 0) pos--;
+
+  cursor.setPosition(pos);
+  m_editor->setTextCursor(cursor);
+}
+
+// ============== DELETE/YANK/CHANGE ==============
 
 void VimMode::deleteText(VimMotion motion, int count) {
   QTextCursor cursor = m_editor->textCursor();
@@ -1221,7 +2052,7 @@ void VimMode::deleteText(VimMotion motion, int count) {
   cursor.setPosition(qMin(startPos, endPos));
   cursor.setPosition(qMax(startPos, endPos), QTextCursor::KeepAnchor);
 
-  m_registerBuffer = cursor.selectedText();
+  deleteToRegister(cursor.selectedText());
   cursor.removeSelectedText();
   m_editor->setTextCursor(cursor);
 }
@@ -1238,7 +2069,7 @@ void VimMode::yankText(VimMotion motion, int count) {
   cursor.setPosition(qMin(startPos, endPos));
   cursor.setPosition(qMax(startPos, endPos), QTextCursor::KeepAnchor);
 
-  m_registerBuffer = cursor.selectedText();
+  yankToRegister(cursor.selectedText());
   cursor.setPosition(startPos);
   m_editor->setTextCursor(cursor);
 
@@ -1246,8 +2077,18 @@ void VimMode::yankText(VimMotion motion, int count) {
 }
 
 void VimMode::changeText(VimMotion motion, int count) {
+  // Open the edit block before deleting so the delete + insert are one undo step
+  QTextCursor cursor = m_editor->textCursor();
+  cursor.beginEditBlock();
+  m_editor->setTextCursor(cursor);
+  m_insertUndoOpen = true;
   deleteText(motion, count);
-  setMode(VimEditMode::Insert);
+  beginChangeRecording(count);
+  trackInsertPosition();
+  m_mode = VimEditMode::Insert;
+  m_editor->setCursorWidth(1);
+  emit modeChanged(m_mode);
+  updatePendingKeys();
 }
 
 void VimMode::insertNewLine(bool above) {
@@ -1265,21 +2106,24 @@ void VimMode::insertNewLine(bool above) {
   m_editor->setTextCursor(cursor);
 }
 
-void VimMode::joinLines() {
+void VimMode::joinLines(int count) {
   QTextCursor cursor = m_editor->textCursor();
-  cursor.movePosition(QTextCursor::EndOfLine);
-  cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
+  cursor.beginEditBlock();
+  for (int c = 0; c < count; ++c) {
+    cursor.movePosition(QTextCursor::EndOfLine);
+    cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
 
-  while (!cursor.atEnd()) {
-    QChar ch = m_editor->document()->characterAt(cursor.position());
-    if (ch.isSpace() && ch != '\n') {
-      cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
-    } else {
-      break;
+    while (!cursor.atEnd()) {
+      QChar ch = m_editor->document()->characterAt(cursor.position());
+      if (ch.isSpace() && ch != '\n')
+        cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
+      else
+        break;
     }
-  }
 
-  cursor.insertText(" ");
+    cursor.insertText(" ");
+  }
+  cursor.endEditBlock();
   m_editor->setTextCursor(cursor);
 }
 
@@ -1297,25 +2141,21 @@ void VimMode::moveCursorToChar(QChar ch, bool before, bool backward) {
   int col = cursor.positionInBlock();
 
   if (backward) {
-
     for (int i = col - 1; i >= 0; --i) {
       if (line[i] == ch) {
         int newPos = before ? i + 1 : i;
         cursor.movePosition(QTextCursor::StartOfLine);
-        cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor,
-                            newPos);
+        cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, newPos);
         m_editor->setTextCursor(cursor);
         return;
       }
     }
   } else {
-
     for (int i = col + 1; i < line.length(); ++i) {
       if (line[i] == ch) {
         int newPos = before ? i - 1 : i;
         cursor.movePosition(QTextCursor::StartOfLine);
-        cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor,
-                            newPos);
+        cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, newPos);
         m_editor->setTextCursor(cursor);
         return;
       }
@@ -1330,54 +2170,26 @@ bool VimMode::moveCursorToMatchingBrace() {
   QChar match;
   bool forward = true;
 
-  if (ch == '(') {
-    match = ')';
-    forward = true;
-  } else if (ch == ')') {
-    match = '(';
-    forward = false;
-  } else if (ch == '[') {
-    match = ']';
-    forward = true;
-  } else if (ch == ']') {
-    match = '[';
-    forward = false;
-  } else if (ch == '{') {
-    match = '}';
-    forward = true;
-  } else if (ch == '}') {
-    match = '{';
-    forward = false;
-  } else if (ch == '<') {
-    match = '>';
-    forward = true;
-  } else if (ch == '>') {
-    match = '<';
-    forward = false;
-  } else {
-    return false;
-  }
+  if (ch == '(') { match = ')'; forward = true; }
+  else if (ch == ')') { match = '('; forward = false; }
+  else if (ch == '[') { match = ']'; forward = true; }
+  else if (ch == ']') { match = '['; forward = false; }
+  else if (ch == '{') { match = '}'; forward = true; }
+  else if (ch == '}') { match = '{'; forward = false; }
+  else if (ch == '<') { match = '>'; forward = true; }
+  else if (ch == '>') { match = '<'; forward = false; }
+  else { return false; }
 
   int depth = 1;
   int pos = cursor.position();
   int len = m_editor->document()->characterCount();
 
   while (depth > 0) {
-    if (forward) {
-      pos++;
-      if (pos >= len)
-        return false;
-    } else {
-      pos--;
-      if (pos < 0)
-        return false;
-    }
-
+    if (forward) { pos++; if (pos >= len) return false; }
+    else { pos--; if (pos < 0) return false; }
     QChar c = m_editor->document()->characterAt(pos);
-    if (c == ch)
-      depth++;
-    else if (c == match)
-      depth--;
+    if (c == ch) depth++;
+    else if (c == match) depth--;
   }
 
   cursor.setPosition(pos);
@@ -1387,25 +2199,17 @@ bool VimMode::moveCursorToMatchingBrace() {
 
 void VimMode::moveCursorToParagraph(bool forward) {
   QTextCursor cursor = m_editor->textCursor();
-
   if (forward) {
-
     while (!cursor.atEnd()) {
       cursor.movePosition(QTextCursor::NextBlock);
-      if (cursor.block().text().trimmed().isEmpty()) {
-        break;
-      }
+      if (cursor.block().text().trimmed().isEmpty()) break;
     }
   } else {
-
     while (!cursor.atStart()) {
       cursor.movePosition(QTextCursor::PreviousBlock);
-      if (cursor.block().text().trimmed().isEmpty()) {
-        break;
-      }
+      if (cursor.block().text().trimmed().isEmpty()) break;
     }
   }
-
   m_editor->setTextCursor(cursor);
 }
 
@@ -1413,40 +2217,61 @@ void VimMode::moveCursorToSentence(bool forward) {
   QTextCursor cursor = m_editor->textCursor();
   QString text = m_editor->toPlainText();
   int pos = cursor.position();
-
   QRegularExpression sentenceEnd("[.!?][\\s\\n]");
 
   if (forward) {
     QRegularExpressionMatch match = sentenceEnd.match(text, pos);
     if (match.hasMatch()) {
       cursor.setPosition(match.capturedEnd());
-
-      while (cursor.position() < text.length() &&
-             text[cursor.position()].isSpace()) {
+      while (cursor.position() < text.length() && text[cursor.position()].isSpace())
         cursor.movePosition(QTextCursor::Right);
-      }
     } else {
       cursor.movePosition(QTextCursor::End);
     }
   } else {
-
     int searchPos = qMax(0, pos - 2);
     int lastMatch = 0;
-    QRegularExpressionMatchIterator it =
-        sentenceEnd.globalMatch(text.left(searchPos));
+    QRegularExpressionMatchIterator it = sentenceEnd.globalMatch(text.left(searchPos));
     while (it.hasNext()) {
       QRegularExpressionMatch m = it.next();
       lastMatch = m.capturedEnd();
     }
     cursor.setPosition(lastMatch);
-
-    while (cursor.position() < text.length() &&
-           text[cursor.position()].isSpace()) {
+    while (cursor.position() < text.length() && text[cursor.position()].isSpace())
       cursor.movePosition(QTextCursor::Right);
-    }
   }
-
   m_editor->setTextCursor(cursor);
+}
+
+void VimMode::moveCursorToScreenLine(int which) {
+  QTextCursor cursor = m_editor->textCursor();
+  QRect rect = m_editor->viewport()->rect();
+  int lineHeight = m_editor->fontMetrics().height();
+  if (lineHeight <= 0) lineHeight = 16;
+  int visibleLines = rect.height() / lineHeight;
+
+  QTextCursor firstVisible = m_editor->cursorForPosition(QPoint(0, 0));
+  int firstLine = firstVisible.blockNumber();
+
+  int targetLine;
+  if (which == 0) // Top
+    targetLine = firstLine;
+  else if (which == 1) // Middle
+    targetLine = firstLine + visibleLines / 2;
+  else // Bottom
+    targetLine = firstLine + visibleLines - 1;
+
+  targetLine = qBound(0, targetLine, m_editor->document()->blockCount() - 1);
+  QTextBlock block = m_editor->document()->findBlockByNumber(targetLine);
+  if (block.isValid()) {
+    cursor.setPosition(block.position());
+    // Move to first non-space
+    QString line = block.text();
+    int p = 0;
+    while (p < line.length() && line[p].isSpace()) p++;
+    cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, p);
+    m_editor->setTextCursor(cursor);
+  }
 }
 
 void VimMode::setMark(QChar mark) {
@@ -1459,37 +2284,24 @@ bool VimMode::jumpToMark(QChar mark) {
     emit statusMessage(QString("Mark '%1' not set").arg(mark));
     return false;
   }
-
   QTextCursor cursor = m_editor->textCursor();
   cursor.setPosition(m_marks[mark]);
   m_editor->setTextCursor(cursor);
   return true;
 }
 
-void VimMode::repeatLastChange() {
-
-  emit statusMessage("Repeat not fully implemented");
-}
-
-void VimMode::recordChange(const QString &change) {
-  m_lastChange = change;
-  m_lastChangeCount = qMax(1, m_count);
-}
-
 void VimMode::searchWord(bool forward) {
-
   QTextCursor cursor = m_editor->textCursor();
   cursor.select(QTextCursor::WordUnderCursor);
   QString word = cursor.selectedText();
-
   if (word.isEmpty()) {
     emit statusMessage("No word under cursor");
     return;
   }
-
   m_searchPattern = "\\b" + QRegularExpression::escape(word) + "\\b";
   m_searchForward = forward;
-
+  m_searchHighlightActive = true;
+  emit searchHighlightRequested(m_searchPattern, true);
   searchNext(forward);
 }
 
@@ -1502,27 +2314,37 @@ void VimMode::searchNext(bool forward) {
   QTextCursor cursor = m_editor->textCursor();
   QString text = m_editor->toPlainText();
   QRegularExpression regex(m_searchPattern);
-
   bool actualForward = (forward == m_searchForward);
+
+  // Collect all match positions for count display
+  QVector<int> matchPositions;
+  QRegularExpressionMatchIterator allMatches = regex.globalMatch(text);
+  while (allMatches.hasNext()) {
+    QRegularExpressionMatch m = allMatches.next();
+    matchPositions.append(m.capturedStart());
+  }
+  int totalMatches = matchPositions.size();
+
+  if (totalMatches == 0) {
+    emit statusMessage("Pattern not found");
+    return;
+  }
+
+  int targetPos = -1;
+  bool wrapped = false;
 
   if (actualForward) {
     QRegularExpressionMatch match = regex.match(text, cursor.position() + 1);
     if (match.hasMatch()) {
-      cursor.setPosition(match.capturedStart());
-      m_editor->setTextCursor(cursor);
+      targetPos = match.capturedStart();
     } else {
-
       match = regex.match(text, 0);
       if (match.hasMatch()) {
-        cursor.setPosition(match.capturedStart());
-        m_editor->setTextCursor(cursor);
-        emit statusMessage("Search wrapped");
-      } else {
-        emit statusMessage("Pattern not found");
+        targetPos = match.capturedStart();
+        wrapped = true;
       }
     }
   } else {
-
     int lastMatch = -1;
     QRegularExpressionMatchIterator it =
         regex.globalMatch(text.left(cursor.position()));
@@ -1530,25 +2352,40 @@ void VimMode::searchNext(bool forward) {
       QRegularExpressionMatch m = it.next();
       lastMatch = m.capturedStart();
     }
-
     if (lastMatch >= 0) {
-      cursor.setPosition(lastMatch);
-      m_editor->setTextCursor(cursor);
+      targetPos = lastMatch;
     } else {
-
       it = regex.globalMatch(text);
       while (it.hasNext()) {
         QRegularExpressionMatch m = it.next();
         lastMatch = m.capturedStart();
       }
       if (lastMatch >= 0) {
-        cursor.setPosition(lastMatch);
-        m_editor->setTextCursor(cursor);
-        emit statusMessage("Search wrapped");
-      } else {
-        emit statusMessage("Pattern not found");
+        targetPos = lastMatch;
+        wrapped = true;
       }
     }
+  }
+
+  if (targetPos >= 0) {
+    cursor.setPosition(targetPos);
+    m_editor->setTextCursor(cursor);
+
+    // Find the 1-based index of the current match
+    int matchIndex = 0;
+    for (int i = 0; i < matchPositions.size(); ++i) {
+      if (matchPositions[i] == targetPos) {
+        matchIndex = i + 1;
+        break;
+      }
+    }
+
+    QString msg = QString("[%1/%2]").arg(matchIndex).arg(totalMatches);
+    if (wrapped)
+      msg += " search wrapped";
+    emit statusMessage(msg);
+  } else {
+    emit statusMessage("Pattern not found");
   }
 }
 
@@ -1563,26 +2400,18 @@ void VimMode::scrollLines(int lines) {
 void VimMode::indentText(VimMotion motion, int count, bool indent) {
   QTextCursor cursor = m_editor->textCursor();
   int startPos = cursor.position();
-
   executeMotion(motion, count);
-
   cursor = m_editor->textCursor();
   int endPos = cursor.position();
 
-  cursor.setPosition(qMin(startPos, endPos));
-  cursor.setPosition(qMax(startPos, endPos), QTextCursor::KeepAnchor);
-
-  int startBlock =
-      m_editor->document()->findBlock(qMin(startPos, endPos)).blockNumber();
-  int endBlock =
-      m_editor->document()->findBlock(qMax(startPos, endPos)).blockNumber();
+  int startBlock = m_editor->document()->findBlock(qMin(startPos, endPos)).blockNumber();
+  int endBlock = m_editor->document()->findBlock(qMax(startPos, endPos)).blockNumber();
 
   cursor.beginEditBlock();
   for (int i = startBlock; i <= endBlock; ++i) {
     QTextBlock block = m_editor->document()->findBlockByNumber(i);
     QTextCursor lineCursor(block);
     lineCursor.movePosition(QTextCursor::StartOfLine);
-
     if (indent) {
       lineCursor.insertText("    ");
     } else {
@@ -1597,7 +2426,6 @@ void VimMode::indentText(VimMotion motion, int count, bool indent) {
     }
   }
   cursor.endEditBlock();
-
   cursor.setPosition(startPos);
   m_editor->setTextCursor(cursor);
 }
@@ -1605,9 +2433,7 @@ void VimMode::indentText(VimMotion motion, int count, bool indent) {
 void VimMode::toggleCase(VimMotion motion, int count) {
   QTextCursor cursor = m_editor->textCursor();
   int startPos = cursor.position();
-
   executeMotion(motion, count);
-
   cursor = m_editor->textCursor();
   int endPos = cursor.position();
 
@@ -1617,16 +2443,39 @@ void VimMode::toggleCase(VimMotion motion, int count) {
   QString text = cursor.selectedText();
   QString result;
   for (const QChar &c : text) {
-    if (c.isLower()) {
-      result += c.toUpper();
-    } else if (c.isUpper()) {
-      result += c.toLower();
-    } else {
-      result += c;
-    }
+    if (c.isLower()) result += c.toUpper();
+    else if (c.isUpper()) result += c.toLower();
+    else result += c;
   }
-
   cursor.insertText(result);
+  cursor.setPosition(qMin(startPos, endPos));
+  m_editor->setTextCursor(cursor);
+}
+
+void VimMode::lowercaseText(VimMotion motion, int count) {
+  QTextCursor cursor = m_editor->textCursor();
+  int startPos = cursor.position();
+  executeMotion(motion, count);
+  cursor = m_editor->textCursor();
+  int endPos = cursor.position();
+
+  cursor.setPosition(qMin(startPos, endPos));
+  cursor.setPosition(qMax(startPos, endPos), QTextCursor::KeepAnchor);
+  cursor.insertText(cursor.selectedText().toLower());
+  cursor.setPosition(qMin(startPos, endPos));
+  m_editor->setTextCursor(cursor);
+}
+
+void VimMode::uppercaseText(VimMotion motion, int count) {
+  QTextCursor cursor = m_editor->textCursor();
+  int startPos = cursor.position();
+  executeMotion(motion, count);
+  cursor = m_editor->textCursor();
+  int endPos = cursor.position();
+
+  cursor.setPosition(qMin(startPos, endPos));
+  cursor.setPosition(qMax(startPos, endPos), QTextCursor::KeepAnchor);
+  cursor.insertText(cursor.selectedText().toUpper());
   cursor.setPosition(qMin(startPos, endPos));
   m_editor->setTextCursor(cursor);
 }
@@ -1645,7 +2494,6 @@ bool VimMode::selectTextObject(VimTextObject textObj) {
   case VimTextObject::AroundWord:
     cursor.select(QTextCursor::WordUnderCursor);
     if (textObj == VimTextObject::AroundWord) {
-
       int end = cursor.selectionEnd();
       if (end < text.length() && text[end].isSpace()) {
         cursor.setPosition(cursor.selectionStart());
@@ -1655,28 +2503,136 @@ bool VimMode::selectTextObject(VimTextObject textObj) {
     m_editor->setTextCursor(cursor);
     return true;
 
+  case VimTextObject::InnerWORD:
+  case VimTextObject::AroundWORD: {
+    // WORD = non-whitespace sequence
+    int start = pos, end = pos;
+    while (start > 0 && !text[start - 1].isSpace()) start--;
+    while (end < text.length() && !text[end].isSpace()) end++;
+    if (textObj == VimTextObject::AroundWORD) {
+      while (end < text.length() && text[end].isSpace()) end++;
+    }
+    cursor.setPosition(start);
+    cursor.setPosition(end, QTextCursor::KeepAnchor);
+    m_editor->setTextCursor(cursor);
+    return true;
+  }
+
+  case VimTextObject::InnerParagraph:
+  case VimTextObject::AroundParagraph: {
+    inner = (textObj == VimTextObject::InnerParagraph);
+    int blockNum = cursor.blockNumber();
+    int startBlock = blockNum, endBlock = blockNum;
+    bool inParagraph = !cursor.block().text().trimmed().isEmpty();
+    if (inParagraph) {
+      while (startBlock > 0 &&
+             !m_editor->document()->findBlockByNumber(startBlock - 1).text().trimmed().isEmpty())
+        startBlock--;
+      while (endBlock < m_editor->document()->blockCount() - 1 &&
+             !m_editor->document()->findBlockByNumber(endBlock + 1).text().trimmed().isEmpty())
+        endBlock++;
+      if (!inner) {
+        while (endBlock < m_editor->document()->blockCount() - 1 &&
+               m_editor->document()->findBlockByNumber(endBlock + 1).text().trimmed().isEmpty())
+          endBlock++;
+      }
+    } else {
+      while (startBlock > 0 &&
+             m_editor->document()->findBlockByNumber(startBlock - 1).text().trimmed().isEmpty())
+        startBlock--;
+      while (endBlock < m_editor->document()->blockCount() - 1 &&
+             m_editor->document()->findBlockByNumber(endBlock + 1).text().trimmed().isEmpty())
+        endBlock++;
+    }
+    QTextBlock startB = m_editor->document()->findBlockByNumber(startBlock);
+    QTextBlock endB = m_editor->document()->findBlockByNumber(endBlock);
+    cursor.setPosition(startB.position());
+    cursor.setPosition(endB.position() + endB.length() - 1, QTextCursor::KeepAnchor);
+    m_editor->setTextCursor(cursor);
+    return true;
+  }
+
+  case VimTextObject::InnerSentence:
+  case VimTextObject::AroundSentence: {
+    // Simple sentence: from previous sentence-end to next sentence-end
+    QRegularExpression sentEnd("[.!?]\\s");
+    int start = 0, end = text.length();
+    // Find sentence start
+    QRegularExpressionMatchIterator it = sentEnd.globalMatch(text.left(pos));
+    while (it.hasNext()) {
+      QRegularExpressionMatch m = it.next();
+      start = m.capturedEnd();
+    }
+    while (start < text.length() && text[start].isSpace()) start++;
+    // Find sentence end
+    QRegularExpressionMatch match = sentEnd.match(text, pos);
+    if (match.hasMatch()) {
+      end = textObj == VimTextObject::InnerSentence ? match.capturedStart() + 1
+                                                     : match.capturedEnd();
+    }
+    cursor.setPosition(start);
+    cursor.setPosition(end, QTextCursor::KeepAnchor);
+    m_editor->setTextCursor(cursor);
+    return true;
+  }
+
+  case VimTextObject::InnerTag:
+  case VimTextObject::AroundTag: {
+    inner = (textObj == VimTextObject::InnerTag);
+    // Find enclosing HTML/XML tags
+    // Search backward for <tag>
+    int openEnd = -1, closeStart = -1;
+    int searchPos = pos;
+    // Find opening tag end
+    for (int i = searchPos; i >= 0; --i) {
+      if (text[i] == '>') {
+        // Check if this is an opening tag (not </...>)
+        int tagStart = text.lastIndexOf('<', i);
+        if (tagStart >= 0 && tagStart < i) {
+          QString tag = text.mid(tagStart, i - tagStart + 1);
+          if (!tag.startsWith("</") && !tag.endsWith("/>")) {
+            openEnd = i + 1;
+            // Find matching closing tag
+            QRegularExpression closeRegex("</" + QRegularExpression::escape(
+                tag.mid(1, tag.indexOf(QRegularExpression("[\\s>]"), 1) - 1)) + ">");
+            QRegularExpressionMatch closeMatch = closeRegex.match(text, openEnd);
+            if (closeMatch.hasMatch()) {
+              closeStart = closeMatch.capturedStart();
+              if (inner) {
+                cursor.setPosition(openEnd);
+                cursor.setPosition(closeStart, QTextCursor::KeepAnchor);
+              } else {
+                cursor.setPosition(tagStart);
+                cursor.setPosition(closeMatch.capturedEnd(), QTextCursor::KeepAnchor);
+              }
+              m_editor->setTextCursor(cursor);
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return false;
+  }
+
   case VimTextObject::InnerParen:
   case VimTextObject::AroundParen:
-    openChar = '(';
-    closeChar = ')';
+    openChar = '('; closeChar = ')';
     inner = (textObj == VimTextObject::InnerParen);
     break;
   case VimTextObject::InnerBracket:
   case VimTextObject::AroundBracket:
-    openChar = '[';
-    closeChar = ']';
+    openChar = '['; closeChar = ']';
     inner = (textObj == VimTextObject::InnerBracket);
     break;
   case VimTextObject::InnerBrace:
   case VimTextObject::AroundBrace:
-    openChar = '{';
-    closeChar = '}';
+    openChar = '{'; closeChar = '}';
     inner = (textObj == VimTextObject::InnerBrace);
     break;
   case VimTextObject::InnerAngle:
   case VimTextObject::AroundAngle:
-    openChar = '<';
-    closeChar = '>';
+    openChar = '<'; closeChar = '>';
     inner = (textObj == VimTextObject::InnerAngle);
     break;
   case VimTextObject::InnerQuote:
@@ -1702,11 +2658,9 @@ bool VimMode::selectTextObject(VimTextObject textObj) {
   }
 
   if (isQuote) {
-
     QString line = cursor.block().text();
     int col = cursor.positionInBlock();
     int lineStart = cursor.position() - col;
-
     int openPos = -1, closePos = -1;
     bool foundOpen = false;
 
@@ -1719,9 +2673,7 @@ bool VimMode::selectTextObject(VimTextObject textObj) {
           }
         } else {
           closePos = i;
-          if (i >= col)
-            break;
-
+          if (i >= col) break;
           openPos = -1;
           closePos = -1;
           foundOpen = false;
@@ -1738,28 +2690,21 @@ bool VimMode::selectTextObject(VimTextObject textObj) {
       return true;
     }
   } else {
-
     int openPos = -1;
     int depth = 0;
 
     for (int i = pos; i >= 0; --i) {
-      if (text[i] == closeChar)
-        depth++;
+      if (text[i] == closeChar) depth++;
       else if (text[i] == openChar) {
-        if (depth == 0) {
-          openPos = i;
-          break;
-        }
+        if (depth == 0) { openPos = i; break; }
         depth--;
       }
     }
 
     if (openPos >= 0) {
-
       depth = 1;
       for (int i = openPos + 1; i < text.length(); ++i) {
-        if (text[i] == openChar)
-          depth++;
+        if (text[i] == openChar) depth++;
         else if (text[i] == closeChar) {
           depth--;
           if (depth == 0) {
@@ -1780,27 +2725,52 @@ bool VimMode::selectTextObject(VimTextObject textObj) {
 
 void VimMode::executeOperatorOnTextObject(VimOperator op,
                                           VimTextObject textObj) {
-  if (!selectTextObject(textObj)) {
+  if (!selectTextObject(textObj))
     return;
-  }
 
   QTextCursor cursor = m_editor->textCursor();
-  m_registerBuffer = cursor.selectedText();
+  QString selected = cursor.selectedText();
 
   switch (op) {
   case VimOperator::Delete:
+    deleteToRegister(selected);
     cursor.removeSelectedText();
     m_editor->setTextCursor(cursor);
     break;
   case VimOperator::Change:
+    cursor.beginEditBlock();
+    m_editor->setTextCursor(cursor);
+    m_insertUndoOpen = true;
+    deleteToRegister(selected);
+    cursor = m_editor->textCursor();
     cursor.removeSelectedText();
     m_editor->setTextCursor(cursor);
-    setMode(VimEditMode::Insert);
+    m_mode = VimEditMode::Insert;
+    m_editor->setCursorWidth(1);
+    emit modeChanged(m_mode);
+    updatePendingKeys();
     break;
   case VimOperator::Yank:
+    yankToRegister(selected);
     cursor.clearSelection();
     m_editor->setTextCursor(cursor);
     emit statusMessage("Yanked");
+    break;
+  case VimOperator::ToggleCase: {
+    QString result;
+    for (const QChar &c : selected) {
+      if (c.isLower()) result += c.toUpper();
+      else if (c.isUpper()) result += c.toLower();
+      else result += c;
+    }
+    cursor.insertText(result);
+    break;
+  }
+  case VimOperator::Lowercase:
+    cursor.insertText(selected.toLower());
+    break;
+  case VimOperator::Uppercase:
+    cursor.insertText(selected.toUpper());
     break;
   default:
     break;

--- a/App/ui/panels/findreplacepanel.cpp
+++ b/App/ui/panels/findreplacepanel.cpp
@@ -1,6 +1,7 @@
 #include "findreplacepanel.h"
 #include "../../core/lightpadtabwidget.h"
 #include "../../core/textarea.h"
+#include "../../editor/vimmode.h"
 #include "../mainwindow.h"
 #include "ui_findreplacepanel.h"
 
@@ -714,6 +715,12 @@ void FindReplacePanel::findInitial(QTextCursor &cursor,
   }
 
   textArea->updateSyntaxHighlightTags(searchWord);
+
+  // Sync search pattern to vim mode so n/N work after Ctrl+F search
+  if (textArea->isVimModeEnabled() && textArea->vimMode() && !m_vimCommandMode) {
+    textArea->vimMode()->setSearchPattern(
+        QRegularExpression::escape(searchWord));
+  }
 
   QRegularExpression pattern = buildSearchPattern(searchWord);
   QString text = textArea->toPlainText();

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -86,22 +86,28 @@ When VIM mode is enabled, the editor uses modal editing with different shortcuts
 > **Note:** In VIM Normal mode, `Ctrl+D` means "Page down" instead of "Duplicate line".
 > Use `:set novim` to disable VIM mode, `:set vim` to re-enable it, or disable VIM mode in preferences.
 
-### Normal Mode
+### Normal Mode — Movement
 
 | Key | Action |
 |-----|--------|
-| `h` | Move left |
-| `j` | Move down |
-| `k` | Move up |
-| `l` | Move right |
-| `w` | Next word |
-| `b` | Previous word |
+| `h` / `←` | Move left |
+| `j` / `↓` | Move down |
+| `k` / `↑` | Move up |
+| `l` / `→` | Move right |
+| `w` | Next word start |
+| `b` | Previous word start |
 | `e` | End of word |
-| `0` | Start of line |
+| `W` | Next WORD start (whitespace-delimited) |
+| `B` | Previous WORD start (whitespace-delimited) |
+| `E` | End of WORD (whitespace-delimited) |
+| `0` | Start of line (column 0) |
 | `$` | End of line |
 | `^` | First non-space character |
 | `gg` | Go to start of file |
-| `G` | Go to end of file |
+| `G` | Go to end of file (or line N with count) |
+| `H` | Move to top of visible screen |
+| `M` | Move to middle of visible screen |
+| `L` | Move to bottom of visible screen |
 | `Ctrl+U` | Half page up |
 | `Ctrl+D` | Half page down |
 | `Ctrl+B` | Full page up |
@@ -127,22 +133,6 @@ When VIM mode is enabled, the editor uses modal editing with different shortcuts
 | `/` | Search forward |
 | `?` | Search backward |
 
-### Command Mode
-
-| Command | Action |
-|---------|--------|
-| `:w` | Save file |
-| `:q` | Close tab |
-| `:wq` / `:x` | Save and close |
-| `:q!` | Quit app |
-| `:e {file}` | Open file |
-| `:{line}` | Go to line |
-| `/pattern` | Search forward |
-| `?pattern` | Search backward |
-| `:s/old/new/` | Replace in line |
-| `:%s/old/new/g` | Replace in file |
-| `↑` / `↓` | Recall previous `:` commands |
-
 ### Mode Switching
 
 | Key | Action |
@@ -160,7 +150,7 @@ When VIM mode is enabled, the editor uses modal editing with different shortcuts
 | `:` | Enter Command mode |
 | `/` | Start forward search |
 | `?` | Start backward search |
-| `Esc` | Return to Normal mode |
+| `Esc` / `Ctrl+[` | Return to Normal mode |
 
 ### Operators (combine with motions)
 
@@ -171,6 +161,9 @@ When VIM mode is enabled, the editor uses modal editing with different shortcuts
 | `y` | Yank (copy) |
 | `>` | Indent |
 | `<` | Unindent |
+| `g~` | Toggle case (with motion) |
+| `gu` | Lowercase (with motion) |
+| `gU` | Uppercase (with motion) |
 | `dd` | Delete line |
 | `yy` | Yank line |
 | `cc` | Change line |
@@ -181,12 +174,20 @@ When VIM mode is enabled, the editor uses modal editing with different shortcuts
 | `D` | Delete to end of line |
 | `C` | Change to end of line |
 
-### Text Objects (use with operators: d, c, y)
+### Text Objects (use with operators: d, c, y, g~, gu, gU)
 
 | Key | Action |
 |-----|--------|
 | `iw` | Inner word |
 | `aw` | Around word (includes space) |
+| `iW` | Inner WORD (whitespace-delimited) |
+| `aW` | Around WORD (includes surrounding space) |
+| `ip` | Inner paragraph |
+| `ap` | Around paragraph (includes trailing blank lines) |
+| `is` | Inner sentence |
+| `as` | Around sentence (includes trailing space) |
+| `it` | Inner HTML/XML tag |
+| `at` | Around HTML/XML tag (includes the tags) |
 | `i(` or `i)` | Inner parentheses |
 | `a(` or `a)` | Around parentheses |
 | `i[` or `i]` | Inner brackets |
@@ -202,14 +203,51 @@ When VIM mode is enabled, the editor uses modal editing with different shortcuts
 | `` i` `` | Inner backticks |
 | `` a` `` | Around backticks |
 
+### Registers
+
+Named registers allow you to store and recall multiple clipboard values.
+
+| Key | Action |
+|-----|--------|
+| `"{reg}` | Use register `{reg}` for the next yank/delete/paste |
+| `"a`–`"z` | Named registers (lowercase writes, uppercase appends) |
+| `"0` | Yank register (last yanked text) |
+| `"1`–`"9` | Delete history (most recent to oldest) |
+| `"+` | System clipboard register |
+| `"_` | Black hole register (discard) |
+| `".` | Last inserted text (read-only) |
+
+Example: `"ayy` yanks the current line into register `a`, `"ap` pastes from register `a`.
+
+### Macros
+
+| Key | Action |
+|-----|--------|
+| `q{a-z}` | Start recording macro into register |
+| `q` | Stop recording macro (when recording) |
+| `@{a-z}` | Play back macro from register |
+| `@@` | Replay last played macro |
+
+The status bar shows **●REC @{reg}** while recording.
+
 ### Marks
 
 | Key | Action |
 |-----|--------|
 | `m{a-z}` | Set mark at cursor position |
-| `'{a-z}` | Jump to mark |
+| `'{a-z}` | Jump to mark (line) |
 
-### Other Commands
+### g-Prefix Commands
+
+| Key | Action |
+|-----|--------|
+| `gi` | Go to last insert position and enter Insert mode |
+| `gv` | Reselect last visual selection |
+| `g~{motion}` | Toggle case over motion |
+| `gu{motion}` | Lowercase over motion |
+| `gU{motion}` | Uppercase over motion |
+
+### Other Normal Mode Commands
 
 | Key | Action |
 |-----|--------|
@@ -220,28 +258,72 @@ When VIM mode is enabled, the editor uses modal editing with different shortcuts
 | `~` | Toggle case of character |
 | `u` | Undo |
 | `Ctrl+R` | Redo |
-| `p` | Paste after |
-| `P` | Paste before |
-| `J` | Join lines |
-| `.` | Repeat last change (partial implementation) |
+| `p` | Paste after cursor |
+| `P` | Paste before cursor |
+| `J` | Join current line with next (supports count) |
+| `.` | Repeat last change |
+| `Ctrl+A` | Increment number under cursor |
+| `Ctrl+X` | Decrement number under cursor |
 | `zz` | Center cursor on screen |
 | `zt` | Scroll cursor to top |
 | `zb` | Scroll cursor to bottom |
 
-### Command Mode
+### Visual Mode
+
+All normal motions work to extend the selection. Additional commands:
+
+| Key | Action |
+|-----|--------|
+| `d` / `x` | Delete selection |
+| `c` / `s` | Change selection (delete and enter Insert) |
+| `y` | Yank selection |
+| `>` | Indent selection |
+| `<` | Unindent selection |
+| `~` | Toggle case of selection |
+| `u` | Lowercase selection |
+| `U` | Uppercase selection |
+| `J` | Join selected lines |
+| `o` | Move cursor to other end of selection |
+
+### Command Mode (Ex Commands)
 
 | Command | Action |
 |---------|--------|
-| `:w` | Save |
-| `:q` | Quit |
-| `:wq` or `:x` | Save and quit |
-| `:q!` | Force quit |
+| `:w` | Save file |
+| `:q` | Close tab |
+| `:wq` / `:x` | Save and close |
+| `:q!` | Force quit application |
+| `:e {file}` | Open file |
 | `:{number}` | Go to line number |
 | `/pattern` | Search forward for pattern |
 | `?pattern` | Search backward for pattern |
-| `:s/old/new` | Substitute on current line |
+| `:s/old/new/` | Substitute on current line |
 | `:%s/old/new/g` | Substitute in entire file |
-| `:e filename` | Edit file |
+| `:noh` / `:nohlsearch` | Clear search highlighting |
+| `:bn` | Next buffer (tab) |
+| `:bp` | Previous buffer (tab) |
+| `:sp` | Split horizontally |
+| `:vsp` | Split vertically |
+| `:sort` | Sort selected lines (or all lines) |
+| `:registers` | Show register contents |
+| `:marks` | Show marks |
+| `↑` / `↓` | Recall previous `:` commands |
+
+### Status Bar Indicators
+
+The vim mode status is shown as a colored badge in the bottom status bar:
+
+| Color | Mode |
+|-------|------|
+| 🟢 Green | NORMAL |
+| 🔵 Blue | INSERT |
+| 🟡 Yellow | VISUAL / VISUAL LINE / VISUAL BLOCK |
+| 🔴 Red | REPLACE |
+| 🟣 Purple | COMMAND |
+
+The status bar also shows:
+- **Pending keys** (e.g., `d` waiting for a motion)
+- **Macro recording indicator** (●REC @{reg})
 
 ## LSP Features
 


### PR DESCRIPTION
- Connect vim searchHighlightRequested signal to syntax highlighter so vim /, ?, *, # searches highlight all matches in the editor
- Add match count display in vim search ([3/15] style)
- Add searchPattern()/setSearchPattern() public API to VimMode
- Pre-populate Ctrl+F search box with vim's last search pattern
- Sync Ctrl+F searches back to vim mode so n/N work after panel search
- Add vimmode.h include to findreplacepanel.cpp for bidirectional sync